### PR TITLE
Add NetFlow version 9 support

### DIFF
--- a/netflow_exporter.py
+++ b/netflow_exporter.py
@@ -146,8 +146,86 @@ def build_netflow_v5_record(src_ip: str, dst_ip: str, nexthop_ip: str, input_if:
 	)
 
 
+# NetFlow v9 support
+V9_TEMPLATE_ID = 256
+V9_FIELDS = [
+	(8, 4),   # IPV4_SRC_ADDR
+	(12, 4),  # IPV4_DST_ADDR
+	(10, 2),  # INPUT_SNMP
+	(14, 2),  # OUTPUT_SNMP
+	(2, 4),   # IN_PKTS
+	(1, 4),   # IN_BYTES
+	(22, 4),  # FIRST_SWITCHED
+	(21, 4),  # LAST_SWITCHED
+	(7, 2),   # L4_SRC_PORT
+	(11, 2),  # L4_DST_PORT
+	(4, 1),   # PROTOCOL
+	(5, 1),   # SRC_TOS
+	(6, 1),   # TCP_FLAGS
+]
 
-def build_and_send_exports(collector_ip: str, collector_port: int, max_records_per_pkt: int = 30) -> None:
+
+def build_netflow_v9_header(count: int, sys_uptime: int, unix_secs: int, sequence: int, source_id: int = 0) -> bytes:
+	# NetFlow v9 header (20 bytes)
+	# version(2)=9, count(2), sys_uptime(4), unix_secs(4), sequence_number(4), source_id(4)
+	return struct.pack("!HHIIII", 9, count, sys_uptime, unix_secs, sequence, source_id)
+
+
+def build_netflow_v9_template_flowset(template_id: int = V9_TEMPLATE_ID) -> bytes:
+	# FlowSet ID 0 (Template), followed by one template definition
+	body = bytearray()
+	field_count = len(V9_FIELDS)
+	body += struct.pack("!HH", int(template_id), int(field_count))
+	for field_type, field_length in V9_FIELDS:
+		body += struct.pack("!HH", int(field_type) & 0xFFFF, int(field_length) & 0xFFFF)
+
+	flowset_id = 0
+	length = 4 + len(body)
+	pad_len = (4 - (length % 4)) % 4
+	return struct.pack("!HH", flowset_id, length + pad_len) + bytes(body) + (b"\x00" * pad_len)
+
+
+def build_netflow_v9_record(
+	src_ip: str,
+	dst_ip: str,
+	input_if: int,
+	output_if: int,
+	d_pkts: int,
+	d_octets: int,
+	first_ms: int,
+	last_ms: int,
+	src_port: int,
+	dst_port: int,
+	proto: int,
+	tos: int,
+	tcp_flags: int,
+) -> bytes:
+	parts = [
+		struct.pack("!I", ip_to_int(src_ip)),
+		struct.pack("!I", ip_to_int(dst_ip)),
+		struct.pack("!H", int(input_if) & 0xFFFF),
+		struct.pack("!H", int(output_if) & 0xFFFF),
+		struct.pack("!I", int(d_pkts) & 0xFFFFFFFF),
+		struct.pack("!I", int(d_octets) & 0xFFFFFFFF),
+		struct.pack("!I", int(first_ms) & 0xFFFFFFFF),
+		struct.pack("!I", int(last_ms) & 0xFFFFFFFF),
+		struct.pack("!H", int(src_port) & 0xFFFF),
+		struct.pack("!H", int(dst_port) & 0xFFFF),
+		struct.pack("!B", int(proto) & 0xFF),
+		struct.pack("!B", int(tos) & 0xFF),
+		struct.pack("!B", int(tcp_flags) & 0xFF),
+	]
+	return b"".join(parts)
+
+
+def build_netflow_v9_data_flowset(records: list, template_id: int = V9_TEMPLATE_ID) -> bytes:
+	body = b"".join(records)
+	length = 4 + len(body)
+	pad_len = (4 - (length % 4)) % 4
+	return struct.pack("!HH", int(template_id), length + pad_len) + body + (b"\x00" * pad_len)
+
+
+def build_and_send_exports(collector_ip: str, collector_port: int, version: str = "5", max_records_per_pkt: int = 30) -> None:
 	global flow_sequence
 
 	if not flows:
@@ -164,54 +242,84 @@ def build_and_send_exports(collector_ip: str, collector_port: int, max_records_p
 		first_rel = clamp_32bit(int(flow["start_time_ms"]) - BOOT_TIME_MS)
 		last_rel = clamp_32bit(int(flow["end_time_ms"]) - BOOT_TIME_MS)
 
-		record_bytes = build_netflow_v5_record(
-			src_ip=src_ip,
-			dst_ip=dst_ip,
-			nexthop_ip="0.0.0.0",
-			input_if=0,
-			output_if=0,
-			d_pkts=int(flow["packets"]),
-			d_octets=int(flow["bytes"]),
-			first_ms=first_rel,
-			last_ms=last_rel,
-			src_port=int(flow["src_port"]),
-			dst_port=int(flow["dst_port"]),
-			tcp_flags=int(flow["tcp_flags"]),
-			proto=int(flow["proto"]),
-			tos=int(flow.get("tos", 0)),
-			src_as=0,
-			dst_as=0,
-			src_mask=0,
-			dst_mask=0,
-		)
+		if str(version) == "9":
+			record_bytes = build_netflow_v9_record(
+				src_ip=src_ip,
+				dst_ip=dst_ip,
+				input_if=0,
+				output_if=0,
+				d_pkts=int(flow["packets"]),
+				d_octets=int(flow["bytes"]),
+				first_ms=first_rel,
+				last_ms=last_rel,
+				src_port=int(flow["src_port"]),
+				dst_port=int(flow["dst_port"]),
+				proto=int(flow["proto"]),
+				tos=int(flow.get("tos", 0)),
+				tcp_flags=int(flow["tcp_flags"]),
+			)
+		else:
+			record_bytes = build_netflow_v5_record(
+				src_ip=src_ip,
+				dst_ip=dst_ip,
+				nexthop_ip="0.0.0.0",
+				input_if=0,
+				output_if=0,
+				d_pkts=int(flow["packets"]),
+				d_octets=int(flow["bytes"]),
+				first_ms=first_rel,
+				last_ms=last_rel,
+				src_port=int(flow["src_port"]),
+				dst_port=int(flow["dst_port"]),
+				tcp_flags=int(flow["tcp_flags"]),
+				proto=int(flow["proto"]),
+				tos=int(flow.get("tos", 0)),
+				src_as=0,
+				dst_as=0,
+				src_mask=0,
+				dst_mask=0,
+			)
 		records_bytes.append(record_bytes)
 
 	if not records_bytes:
 		logging.debug("No records to export")
 		return
 
-	# Chunk into valid NetFlow v5 datagrams: header + up to 30 records
+	# Chunk into valid NetFlow datagrams
 	sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 	try:
 		for i in range(0, len(records_bytes), max_records_per_pkt):
 			chunk = records_bytes[i : i + max_records_per_pkt]
-			header = build_netflow_v5_header(
-				count=len(chunk),
-				sys_uptime=sys_uptime,
-				unix_secs=unix_secs,
-				unix_nsecs=unix_nsecs,
-				sequence=flow_sequence,
-				engine_type=0,
-				engine_id=0,
-				sampling_interval=0,
-			)
-			payload = header + b"".join(chunk)
+			if str(version) == "9":
+				header = build_netflow_v9_header(
+					count=len(chunk),
+					sys_uptime=sys_uptime,
+					unix_secs=unix_secs,
+					sequence=flow_sequence,
+					source_id=0,
+				)
+				template_fs = build_netflow_v9_template_flowset()
+				data_fs = build_netflow_v9_data_flowset(chunk)
+				payload = header + template_fs + data_fs
+			else:
+				header = build_netflow_v5_header(
+					count=len(chunk),
+					sys_uptime=sys_uptime,
+					unix_secs=unix_secs,
+					unix_nsecs=unix_nsecs,
+					sequence=flow_sequence,
+					engine_type=0,
+					engine_id=0,
+					sampling_interval=0,
+				)
+				payload = header + b"".join(chunk)
 
 			# Send UDP datagram
 			sock.sendto(payload, (collector_ip, int(collector_port)))
 			logging.info(
-				"Exported %d flows (seq=%d) -> %s:%d payload=%dB",
+				"Exported %d flows (v%s seq=%d) -> %s:%d payload=%dB",
 				len(chunk),
+				str(version),
 				flow_sequence,
 				collector_ip,
 				collector_port,
@@ -228,10 +336,10 @@ def build_and_send_exports(collector_ip: str, collector_port: int, max_records_p
 
 
 
-def export_timer(collector_ip: str, collector_port: int, interval_seconds: int) -> None:
+def export_timer(collector_ip: str, collector_port: int, interval_seconds: int, version: str) -> None:
 	while True:
 		try:
-			build_and_send_exports(collector_ip, collector_port)
+			build_and_send_exports(collector_ip, collector_port, version=version)
 		except Exception as exc:
 			logging.exception("Export error: %s", exc)
 		finally:
@@ -240,11 +348,12 @@ def export_timer(collector_ip: str, collector_port: int, interval_seconds: int) 
 
 
 def main() -> None:
-	parser = argparse.ArgumentParser(description="Simple NetFlow v5 exporter using Scapy")
+	parser = argparse.ArgumentParser(description="Simple NetFlow exporter (v5 or v9) using Scapy")
 	parser.add_argument("--iface", default=os.environ.get("NETFLOW_IFACE", ""), help="Interface to sniff (default: auto)")
 	parser.add_argument("--collector-ip", default=os.environ.get("NETFLOW_COLLECTOR", "127.0.0.1"), help="Collector IPv4 address")
 	parser.add_argument("--collector-port", type=int, default=int(os.environ.get("NETFLOW_PORT", "2055")), help="Collector UDP port (default: 2055)")
 	parser.add_argument("--interval", type=int, default=int(os.environ.get("NETFLOW_INTERVAL", "15")), help="Export interval in seconds (default: 15)")
+	parser.add_argument("--version", choices=["5", "9"], default=os.environ.get("NETFLOW_VERSION", "5"), help="NetFlow version to export (5 or 9)")
 	args = parser.parse_args()
 
 	iface = args.iface or get_default_interface()
@@ -253,10 +362,10 @@ def main() -> None:
 
 	logging.info("Interfaces available: %s", get_if_list())
 	logging.info("Using interface: %s", iface)
-	logging.info("Collector: %s:%d | interval=%ss", args.collector_ip, args.collector_port, args.interval)
+	logging.info("Collector: %s:%d | interval=%ss | version=v%s", args.collector_ip, args.collector_port, args.interval, args.version)
 
 	# Start exporter thread
-	t = threading.Thread(target=export_timer, args=(args.collector_ip, args.collector_port, args.interval), daemon=True)
+	t = threading.Thread(target=export_timer, args=(args.collector_ip, args.collector_port, args.interval, args.version), daemon=True)
 	t.start()
 
 	# Start sniffer


### PR DESCRIPTION
Add support for NetFlow version 9 to the exporter to allow users to choose the desired protocol version.

The original code only supported NetFlow v5. This change introduces the necessary structures and logic to generate and send NetFlow v9 packets, including template and data flowsets, allowing for more modern NetFlow collection.

---
<a href="https://cursor.com/background-agent?bcId=bc-87c1b8e3-d1e3-493e-862d-574ed6fe42ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87c1b8e3-d1e3-493e-862d-574ed6fe42ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

